### PR TITLE
Fix trail visibility issues when camera is in close proximity

### DIFF
--- a/src/components/DropupMenus.tsx
+++ b/src/components/DropupMenus.tsx
@@ -63,7 +63,7 @@ function DropupMenus({ onIntegratorChange, onOrbitChange }: DropupMenusProps) {
             )}
           </button>
           {orbitMenuOpen && (
-            <ul className="absolute bottom-full mb-2 w-32 supports-backdrop-blur:bg-white/90 backdrop-blur-xl text-zinc-300 rounded-md overflow-hidden">
+            <ul className="absolute bottom-full mb-2 w-36 supports-backdrop-blur:bg-white/90 backdrop-blur-xl text-zinc-300 rounded-md overflow-hidden max-h-60 overflow-y-auto">
               {orbitOptions.map((option, index) => (
                 <li
                   key={index}
@@ -104,7 +104,7 @@ function DropupMenus({ onIntegratorChange, onOrbitChange }: DropupMenusProps) {
           )}
         </button>
         {integratorMenuOpen && (
-          <ul className="absolute bottom-full mb-2 w-32 supports-backdrop-blur:bg-white/90 backdrop-blur-xl text-zinc-300 rounded-md overflow-hidden">
+          <ul className="absolute bottom-full mb-2 w-32 supports-backdrop-blur:bg-white/90 backdrop-blur-xl text-zinc-300 rounded-md overflow-hidden max-h-48 overflow-y-auto">
             {integratorOptions.map((option, index) => (
               <li
                 key={index}

--- a/src/components/ThreeBodyAnimation.tsx
+++ b/src/components/ThreeBodyAnimation.tsx
@@ -145,7 +145,7 @@ function SimulationBody({
         <meshStandardMaterial color={body.color} />
       </mesh>
 
-      <points>
+      <points frustumCulled={false}>
         <bufferGeometry ref={trailRef} />
         <primitive object={shaderMaterial} />
       </points>


### PR DESCRIPTION
## Issue:

When the camera gets close to the simulation bodies (or in some awkward position), their trails disappear from view due to frustum culling, as demonstrated below: 

<img width="1192" alt="SCR-20250302-ukte" src="https://github.com/user-attachments/assets/d7b60ddb-5d92-4141-a3a3-b7b47e2e639c" />

## Solution:

Disable frustum culling on \<points\>.

## Result:

<img width="1189" alt="SCR-20250302-ujys" src="https://github.com/user-attachments/assets/8a21203d-44cf-48d0-adcd-79c6cc56dc90" />

## Context:

Because the trail points can be everywhere all at once you might as well always show them.